### PR TITLE
Import filters from AdGuard

### DIFF
--- a/Filters
+++ b/Filters
@@ -739,3 +739,6 @@ republika.mk,hitportal.com.mk##p > a[target="_BLANK"] > img
 republika.mk##.monadplug-native-grid-wrapper
 stream.mk#@#.ad-placement
 stream.mk#$##ablockercheck { display: block !important; }
+||sportski.mk/wp-content/uploads/*/1920x1080-1.png
+sportski.mk#$#body { background-image: none !important; }
+sportski.mk###icegram_messages_container

--- a/Filters
+++ b/Filters
@@ -731,3 +731,5 @@ bitolanews.mk##.clever-core-ads
 fokus.mk,alsat.mk##div[data-advadstrackid]
 ||adserver.piksel.mk/
 ||tagx.bambarmedia.com/
+tera.mk##.block-commercial
+tera.mk##.carousel-slider-outer-image-carousel

--- a/Filters
+++ b/Filters
@@ -724,3 +724,7 @@ bitolanews.mk##.size-full.alignnone
 alsat.mk##[href^="https://linker.mk/link.php"]
 ||a.kajgana.com/*.$image
 kajgana.com##[href^="https://a.kajgana.com/www/delivery/ck.php"]
+bitolanews.mk##.sidebar > div.inner > section.widget_media_image
+bitolanews.mk##.sidebar > div.inner > section.widget_slideshow
+bitolanews.mk##.widget-area-above-main
+bitolanews.mk##.clever-core-ads

--- a/Filters
+++ b/Filters
@@ -742,3 +742,4 @@ stream.mk#$##ablockercheck { display: block !important; }
 ||sportski.mk/wp-content/uploads/*/1920x1080-1.png
 sportski.mk#$#body { background-image: none !important; }
 sportski.mk###icegram_messages_container
+||free.xjs.lol^

--- a/Filters
+++ b/Filters
@@ -728,3 +728,6 @@ bitolanews.mk##.sidebar > div.inner > section.widget_media_image
 bitolanews.mk##.sidebar > div.inner > section.widget_slideshow
 bitolanews.mk##.widget-area-above-main
 bitolanews.mk##.clever-core-ads
+fokus.mk,alsat.mk##div[data-advadstrackid]
+||adserver.piksel.mk/
+||tagx.bambarmedia.com/

--- a/Filters
+++ b/Filters
@@ -733,3 +733,7 @@ fokus.mk,alsat.mk##div[data-advadstrackid]
 ||tagx.bambarmedia.com/
 tera.mk##.block-commercial
 tera.mk##.carousel-slider-outer-image-carousel
+hitportal.com.mk##.textwidget > a[target="_BLANK"] > img
+republika.mk,hitportal.com.mk##p > a[target="_BLANK"] > img
+||republika.mk/banners/
+republika.mk##.monadplug-native-grid-wrapper

--- a/Filters
+++ b/Filters
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
 ! Title: Macedonian adBlock Filters
 ! Expires: 1 day
-! Last update: 3 March 2023
+! Last update: 18 March 2023
 ! Issue tracker: https://github.com/DeepSpaceHarbor/Macedonian-adBlock-Filters/issues
 
 ###kae_unique_id_0

--- a/Filters
+++ b/Filters
@@ -737,3 +737,5 @@ hitportal.com.mk##.textwidget > a[target="_BLANK"] > img
 republika.mk,hitportal.com.mk##p > a[target="_BLANK"] > img
 ||republika.mk/banners/
 republika.mk##.monadplug-native-grid-wrapper
+stream.mk#@#.ad-placement
+stream.mk#$##ablockercheck { display: block !important; }


### PR DESCRIPTION
Changelog:
- Import filters from AdGuard as suggested in #4.
- Review the websites with the new filters, and add missing filters when needed. 