### PR TITLE
remove bait

### DIFF
--- a/Filters
+++ b/Filters
@@ -5,7 +5,6 @@
 ! Issue tracker: https://github.com/DeepSpaceHarbor/Macedonian-adBlock-Filters/issues
 
 ###kae_unique_id_0
-##.adsbygoogle
 24vesti.com.mk###block-views-kgn_advertisment-block_2
 24vesti.mk###block-views-kgn_advertisment-block_2 > .content
 a1on.mk###sidebar


### PR DESCRIPTION
the filter is used as bait; AdGuard and uBlock Origin exclude it if I'm not wrong